### PR TITLE
ARM64 JIT correctness, Legacy3D rendering fixes, and libretro input/reset fixes

### DIFF
--- a/Src/CPU/PowerPC/Jit/JitArm64.cpp
+++ b/Src/CPU/PowerPC/Jit/JitArm64.cpp
@@ -2587,6 +2587,17 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
     int sub = (op >> 1) & 0x3FF;
     (void)rA;  // some sub-ops don't use rA
 
+    // The A-form ops fsel/fmul/fmsub/fmadd/fnmsub/fnmadd encode frC in bits 6-10, which overlap
+    // the 10-bit `sub`. Without collapsing it, only their frC==0 forms matched and every real
+    // fmul/fmadd fell back to the interpreter. Reduce these to their 5-bit opcode so they match
+    // for any frC; the codes {23,25,28..31} collide with no X-form op in the switch below (the
+    // interpreter fills all 32 frC slots for exactly these — see optable63 in ppc.cpp).
+    {
+        int lo = sub & 0x1F;
+        if (lo == 23 || lo == 25 || (lo >= 28 && lo <= 31))
+            sub = lo;
+    }
+
     switch (sub) {
     case 72:  // fmr rD, rB  (copy FPR)
         emit_load_fpr(e, D0, rB);
@@ -2778,7 +2789,10 @@ static bool translate_op59(Arm64Emitter &e, uint32_t op)
     int rA  = (op >> 16) & 0x1F;
     int rB  = (op >> 11) & 0x1F;
     int rC  = (op >> 6)  & 0x1F;
-    int sub = (op >> 1) & 0x3FF;
+    // Opcode 59 is entirely A-form (single-precision arithmetic); every XO fits in 5 bits and
+    // there are no X-form ops here, so mask to 5 bits. A 10-bit mask would fold the frC field
+    // into the opcode and make fmuls (and the fmadds family) fall back for any frC != 0.
+    int sub = (op >> 1) & 0x1F;
 
 // Round to single precision, store, then update FPSCR[FPRF] — matches the interpreter, which
 // runs set_fprf after every single-precision arithmetic op. (op59 uses STORE_SP only for

--- a/Src/CPU/PowerPC/Jit/JitArm64.cpp
+++ b/Src/CPU/PowerPC/Jit/JitArm64.cpp
@@ -2564,6 +2564,17 @@ static bool translate_stfd(Arm64Emitter &e, uint32_t op, bool update)
     return true;
 }
 
+// Emit a call to jit_set_fprf(rD), replicating the interpreter's set_fprf() side-effect after
+// an FP *arithmetic* result is stored. Every interpreter FP arithmetic op updates FPSCR[FPRF];
+// the JIT computed the right value but omitted the flag, which broke Daytona 2's opponent AI
+// (it reads FPRF back via mffs/mcrfs). Call ONLY after ops the interpreter runs set_fprf for —
+// never after moves (fmr/fneg/fabs), compares (fcmp) or fsel, which leave FPRF untouched.
+static void emit_set_fprf(Arm64Emitter &e, int rD)
+{
+    e.MOV_W32(W0, rD);
+    emit_call(e, (uint64_t)(void *)&jit_set_fprf);
+}
+
 // ---------------------------------------------------------------------------
 // Opcode 63: floating-point double-precision arithmetic
 // ---------------------------------------------------------------------------
@@ -2619,6 +2630,7 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D1, rB);
         e.FADD_D(D0, D0, D1);
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 20:  // fsub rD, rA, rB
@@ -2626,6 +2638,7 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D1, rB);
         e.FSUB_D(D0, D0, D1);
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 25:  // fmul rD, rA, rC  (note: uses rC not rB!)
@@ -2633,6 +2646,7 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D1, rC);
         e.FMUL_D(D0, D0, D1);
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 18:  // fdiv rD, rA, rB
@@ -2640,12 +2654,14 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D1, rB);
         e.FDIV_D(D0, D0, D1);
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 22:  // fsqrt rD, rB
         emit_load_fpr(e, D0, rB);
         e.FSQRT_D(D0, D0);
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 29:  // fmadd rD, rA, rC, rB  (rD = rA*rC + rB)
@@ -2654,6 +2670,7 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D2, rB);
         e.FMADD_D(D0, D0, D1, D2);   // D0 = D2 + D0*D1 = rB + rA*rC
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 28:  // fmsub rD, rA, rC, rB  (rD = rA*rC - rB)
@@ -2663,6 +2680,7 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D2, rB);
         e.FNMSUB_D(D0, D0, D1, D2);  // D0*D1 - D2 = rA*rC - rB
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 31:  // fnmadd rD, rA, rC, rB  (rD = -(rA*rC + rB))
@@ -2671,6 +2689,7 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D2, rB);
         e.FNMADD_D(D0, D0, D1, D2);  // -(D2 + D0*D1) = -(rB + rA*rC) ✓
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 30:  // fnmsub rD, rA, rC, rB  (rD = -(rA*rC - rB) = rB - rA*rC)
@@ -2680,6 +2699,7 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D2, rB);
         e.FMSUB_D(D0, D0, D1, D2);   // D2 - D0*D1 = rB - rA*rC
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
 
     case 23: {// fsel frD, frA, frC, frB  (frD = frA >= 0.0 ? frC : frB; NaN → frB)
@@ -2697,6 +2717,7 @@ static bool translate_op63(Arm64Emitter &e, uint32_t op)
         emit_load_fpr(e, D0, rB);
         emit_call(e, (uint64_t)(void *)&jit_frsqrte);
         emit_store_fpr(e, D0, rD);
+        emit_set_fprf(e, rD);
         return true;
     }
 
@@ -2759,7 +2780,10 @@ static bool translate_op59(Arm64Emitter &e, uint32_t op)
     int rC  = (op >> 6)  & 0x1F;
     int sub = (op >> 1) & 0x3FF;
 
-#define STORE_SP(Dd, ppc_fpr) do { e.FCVT_S_D(Dd, Dd); e.FCVT_D_S(Dd, Dd); emit_store_fpr(e, Dd, ppc_fpr); } while(0)
+// Round to single precision, store, then update FPSCR[FPRF] — matches the interpreter, which
+// runs set_fprf after every single-precision arithmetic op. (op59 uses STORE_SP only for
+// arithmetic ops, so baking the FPRF update in here is correct for all of them.)
+#define STORE_SP(Dd, ppc_fpr) do { e.FCVT_S_D(Dd, Dd); e.FCVT_D_S(Dd, Dd); emit_store_fpr(e, Dd, ppc_fpr); emit_set_fprf(e, ppc_fpr); } while(0)
 
     switch (sub) {
     case 20:  // fsubs rD, rA, rB — interpreter: block-extension causes visual corruption

--- a/Src/CPU/PowerPC/Jit/JitArm64.h
+++ b/Src/CPU/PowerPC/Jit/JitArm64.h
@@ -31,6 +31,7 @@ extern void      jit_write64(UINT32 addr, UINT64 data);
 extern double    jit_fres(double x);
 extern double    jit_frsqrte(double x);
 extern double    jit_frsp(double x);    // round double to single precision and back
+extern void      jit_set_fprf(UINT32 rD); // update FPSCR[FPRF] from FPR[rD] after a JIT FP op
 #ifdef __cplusplus
 }
 #endif

--- a/Src/CPU/PowerPC/ppc.cpp
+++ b/Src/CPU/PowerPC/ppc.cpp
@@ -1183,4 +1183,9 @@ double jit_fres(double x)    { return (double)(1.0f / (float)x); }
 double jit_frsqrte(double x) { return 1.0 / sqrt(x); }
 double jit_frsp(double x)    { return (double)(float)x; }
 
+// The interpreter's FP arithmetic updates FPSCR[FPRF] (result class/sign) via set_fprf().
+// The JIT computes the correct result but omitted this flag; Daytona 2's opponent AI reads
+// it back (mffs/mcrfs) and misbehaves without it. Call after a JIT FP op stores FPR[rD].
+void jit_set_fprf(UINT32 rD) { set_fprf(FPR(rD)); }
+
 } // extern "C"

--- a/Src/Graphics/Legacy3D/Legacy3D.cpp
+++ b/Src/Graphics/Legacy3D/Legacy3D.cpp
@@ -988,6 +988,13 @@ void CLegacy3D::RenderFrame(void)
   glDepthFunc(GL_LESS);
   glEnable(GL_DEPTH_TEST);
 
+  // Backface culling. Must be re-set per frame, not once at init: the libretro frontend
+  // shares our GL context and renders its own passes between frames, which leaves culling
+  // disabled. Without it back faces are drawn and win coplanar draws by pure ordering.
+  glFrontFace(GL_CW);   // polygons are uploaded w/ clockwise winding
+  glCullFace(GL_BACK);
+  glEnable(GL_CULL_FACE);
+
   // Stencil buffering
   glStencilFunc(GL_EQUAL, 0, 0xFF);       // stencil test passes if stencil buffer value is 0
   glStencilOp(GL_KEEP, GL_INCR, GL_INCR); // if the stencil test passes, increment value in stencil buffer
@@ -1305,9 +1312,8 @@ Result CLegacy3D::SetupGLObjects()
         glUniform1f(mapSizeLoc, (GLfloat)mapSize);
 
     // Additional OpenGL stuff
-    glFrontFace(GL_CW);   // polygons are uploaded w/ clockwise winding
-    glCullFace(GL_BACK);
-    glEnable(GL_CULL_FACE);
+    // (front face / cull face / GL_CULL_FACE are set per frame in RenderFrame(); setting
+    //  them here too would be dead state, as the frontend resets them between frames)
     glClearDepth(1.0);
     // glEnable(GL_TEXTURE_2D) was fixed-function texturing state; meaningless
     // once every draw goes through a shader, and invalid in GLES.

--- a/Src/Graphics/Legacy3D/Models.cpp
+++ b/Src/Graphics/Legacy3D/Models.cpp
@@ -736,7 +736,12 @@ void CLegacy3D::InsertVertex(ModelCache *Cache, const Vertex *V, const Poly *P, 
   GLfloat translucence = (GLfloat) ((P->header[6]>>18)&0x1F) * (1.0f/31.0f);
   if ((P->header[6]&0x00800000))  // if set, polygon is opaque
     translucence = 1.0f;
-    
+  // ponytail: Sega Rally 2 smoke = dense overlapping RGBA4 (format 7) translucent polys whose
+  // alpha-blend accumulates into opaque cones in Legacy3D. New3D keeps them light. Cut per-poly
+  // alpha hard so the overlapping stack stays faint. Factor tuned to ~match New3D's light smoke.
+  if (texFormat == 7 && !(P->header[6] & 0x00800000) && (P->header[6] & 0x80000000))
+    translucence *= 0.2f;
+
   // Fog intensity (apparently used for both luminous and shaded polygons)
   GLfloat fogIntensity = (GLfloat) ((P->header[6]>>11)&0x1F) * (1.0f/15.0f);  // only 4 bits seem to actually be used?
 

--- a/Src/OSD/libretro/CLibretroInputSystem.cpp
+++ b/Src/OSD/libretro/CLibretroInputSystem.cpp
@@ -117,8 +117,27 @@ bool CLibretroInputSystem::Poll()
                                    RETRO_DEVICE_INDEX_ANALOG_LEFT,
                                    RETRO_DEVICE_ID_ANALOG_Y);
 
-        m_joyAxes[joy][0] = x;
-        m_joyAxes[joy][1] = y;
+        m_joyAxes[joy][AXIS_X] = x;
+        m_joyAxes[joy][AXIS_Y] = y;
+
+        // Right stick -> RX/RY, which the analog driving layout uses as a gate shifter
+        // (JOY1_RYAXIS_NEG/POS = gears 1/2, JOY1_RXAXIS_NEG/POS = gears 3/4).
+        m_joyAxes[joy][AXIS_RX] = input_state_cb(joy, RETRO_DEVICE_ANALOG,
+                                                 RETRO_DEVICE_INDEX_ANALOG_RIGHT,
+                                                 RETRO_DEVICE_ID_ANALOG_X);
+        m_joyAxes[joy][AXIS_RY] = input_state_cb(joy, RETRO_DEVICE_ANALOG,
+                                                 RETRO_DEVICE_INDEX_ANALOG_RIGHT,
+                                                 RETRO_DEVICE_ID_ANALOG_Y);
+
+        // Triggers as analog axes (0..32767). Frontends with only digital L2/R2 report 0 or
+        // 32767 here, so this is safe either way. L2 -> ZAXIS, R2 -> RZAXIS, matching how
+        // Supermodel names trigger axes elsewhere.
+        m_joyAxes[joy][AXIS_Z]  = input_state_cb(joy, RETRO_DEVICE_ANALOG,
+                                                 RETRO_DEVICE_INDEX_ANALOG_BUTTON,
+                                                 RETRO_DEVICE_ID_JOYPAD_L2);
+        m_joyAxes[joy][AXIS_RZ] = input_state_cb(joy, RETRO_DEVICE_ANALOG,
+                                                 RETRO_DEVICE_INDEX_ANALOG_BUTTON,
+                                                 RETRO_DEVICE_ID_JOYPAD_R2);
 
         // ----- D-Pad -----
         bool d_up    = input_state_cb(joy, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP);
@@ -200,7 +219,7 @@ bool CLibretroInputSystem::IsJoyButPressed(int joyNum, int butNum) const
 int CLibretroInputSystem::GetJoyAxisValue(int joyNum, int axisNum) const
 {
     if (joyNum < 0 || joyNum >= 2) return 0;
-    if (axisNum < 0 || axisNum >= 2) return 0;
+    if (axisNum < 0 || axisNum >= NUM_JOY_AXES) return 0;
     return m_joyAxes[joyNum][axisNum];
 }
 
@@ -374,10 +393,14 @@ const JoyDetails *CLibretroInputSystem::GetJoyDetails(int joyNum)
             std::memset(&d[i], 0, sizeof(d[i]));
             std::strncpy(d[i].name, "Libretro Joypad", MAX_NAME_LENGTH);
             d[i].numButtons = 32;
-            d[i].numAxes = 2;
+            d[i].numAxes = 6;   // left stick, right stick, and the two triggers
             d[i].numPOVs = 1;
-            d[i].hasAxis[0] = true;
-            d[i].hasAxis[1] = true;
+            d[i].hasAxis[AXIS_X]  = true;   // left stick
+            d[i].hasAxis[AXIS_Y]  = true;
+            d[i].hasAxis[AXIS_Z]  = true;   // L2
+            d[i].hasAxis[AXIS_RX] = true;   // right stick
+            d[i].hasAxis[AXIS_RY] = true;
+            d[i].hasAxis[AXIS_RZ] = true;   // R2
             d[i].hasFFeedback = true;
             for (int a = 0; a < NUM_JOY_AXES; a++)
                 d[i].axisHasFF[a] = true;

--- a/Src/OSD/libretro/CoreOptionsTypes.h
+++ b/Src/OSD/libretro/CoreOptionsTypes.h
@@ -1,6 +1,14 @@
 #ifndef SUPERMODEL_CORE_OPTIONS_TYPES_H
 #define SUPERMODEL_CORE_OPTIONS_TYPES_H
 
+// Pad layout for driving games. The two analog layouts differ only in what the right stick
+// does: a gate shifter (4 gears) or a sequential lever (up/down). It cannot be both.
+enum class DrivingLayout {
+   Default,            // pedals on the d-pad, gears 1-4 on L/R/L2/R2
+   TriggersGate,       // pedals on the triggers, gears 1-4 on the right stick
+   TriggersSequential  // pedals on the triggers, sequential shift on the right stick
+};
+
 struct CoreOptions {
    float resolution_multiplier;
    bool widescreen;
@@ -16,6 +24,7 @@ struct CoreOptions {
    bool sound_enable;
    bool jit_enable;
    bool timing_overlay;      // draw the ImGui frame-timing overlay (costs a draw pass every frame)
+   DrivingLayout driving_layout;
 };
 
 extern CoreOptions g_options;

--- a/Src/OSD/libretro/LibretroConfigProvider.h
+++ b/Src/OSD/libretro/LibretroConfigProvider.h
@@ -2,6 +2,7 @@
 #include <Inputs/InputSystem.h>
 #include "Util/NewConfig.h"
 #include "LibretroWrapper.h"
+#include "CoreOptionsTypes.h"
 #include <algorithm>
 namespace LibretroConfigProvider {
      inline Util::Config::Node DefaultConfig(const std::string& gameXmlPath)
@@ -591,5 +592,54 @@ namespace LibretroConfigProvider {
         cmd_line.rom_files.emplace_back(arg);
     }
     return cmd_line;
+    }
+
+    /*
+     * Applies the driving control layout chosen in the core options.
+     *
+     * Must run on the *merged* runtime config, not in DefaultConfig(): the on-disk
+     * Supermodel.ini is merged over the defaults and carries a full set of Input* mappings,
+     * so anything DefaultConfig() sets is overwritten by the file. Does nothing on the default
+     * layout, so a hand-edited ini keeps its mappings unless a layout is explicitly chosen.
+     *
+     * Both analog layouts put the pedals on the triggers and shift sequentially with L/R;
+     * they differ in what the right stick is. It cannot be both a gate and a lever, so the
+     * sequential layout drops the 4 direct gears from the pad (keyboard keeps them). Either
+     * way the same gearbox is driven: CGearShift4Input takes the direct gears *and* up/down.
+     *
+     * The d-pad pedal source is dropped rather than kept beside the axis: CMultiInputSource
+     * (OR) answers with the first *active* source, and a digital source read as an analog one
+     * decays over several frames after release (CJoyPOVInputSource), during which it would
+     * keep overriding the trigger. Gears are switch inputs, so mixing button and axis sources
+     * there is free (CJoyAxisInputSource::GetValueAsSwitch trips past ~2/3 of travel).
+     */
+    inline void ApplyDrivingLayout(Util::Config::Node &config)
+    {
+        if (g_options.driving_layout == DrivingLayout::Default)
+            return;
+
+        config.Set<std::string>("InputAccelerator", "KEY_UP,JOY1_RZAXIS_POS");   // R2
+        config.Set<std::string>("InputBrake", "KEY_DOWN,JOY1_ZAXIS_POS");        // L2
+
+        if (g_options.driving_layout == DrivingLayout::TriggersSequential)
+        {
+            // Right stick = sequential lever; no 4-gear gate on the pad
+            config.Set<std::string>("InputGearShiftUp", "KEY_Y,JOY1_BUTTON6,JOY1_RYAXIS_NEG");
+            config.Set<std::string>("InputGearShiftDown", "KEY_H,JOY1_BUTTON5,JOY1_RYAXIS_POS");
+            config.Set<std::string>("InputGearShift1", "KEY_Q");
+            config.Set<std::string>("InputGearShift2", "KEY_W");
+            config.Set<std::string>("InputGearShift3", "KEY_E");
+            config.Set<std::string>("InputGearShift4", "KEY_R");
+        }
+        else
+        {
+            // Right stick = 4-gear gate
+            config.Set<std::string>("InputGearShiftUp", "KEY_Y,JOY1_BUTTON6");       // R
+            config.Set<std::string>("InputGearShiftDown", "KEY_H,JOY1_BUTTON5");     // L
+            config.Set<std::string>("InputGearShift1", "KEY_Q,JOY1_RYAXIS_NEG");     // stick up
+            config.Set<std::string>("InputGearShift2", "KEY_W,JOY1_RYAXIS_POS");     // stick down
+            config.Set<std::string>("InputGearShift3", "KEY_E,JOY1_RXAXIS_NEG");     // stick left
+            config.Set<std::string>("InputGearShift4", "KEY_R,JOY1_RXAXIS_POS");     // stick right
+        }
     }
 }

--- a/Src/OSD/libretro/LibretroWrapper.cpp
+++ b/Src/OSD/libretro/LibretroWrapper.cpp
@@ -548,10 +548,7 @@ int LibretroWrapper::Supermodel(const Game &game, bool skipRender)
     }
     else if (Inputs->uiReset->Pressed())
     {
-      if (!paused) Model3->PauseThreads();
-      Model3->Reset();
-      if (!paused) Model3->ResumeThreads();
-      puts("Model 3 reset.");
+      Reset();
     }
     else if (Inputs->uiPause->Pressed())
     {
@@ -710,6 +707,18 @@ Result LibretroWrapper::ConfigureInputs(CInputs *Inputs, Util::Config::Node *fil
   }
 
   return Result::OKAY;
+}
+
+// Same sequence as the uiReset hotkey handler: the render/sound threads must be parked
+// while the machine is reset, or they keep touching state that Reset() is tearing down.
+void LibretroWrapper::Reset()
+{
+    if (!Model3)
+        return;
+    if (!paused) Model3->PauseThreads();
+    Model3->Reset();
+    if (!paused) Model3->ResumeThreads();
+    InfoLog("Model 3 reset.");
 }
 
 int LibretroWrapper::Emulate(const char* romPath)

--- a/Src/OSD/libretro/LibretroWrapper.cpp
+++ b/Src/OSD/libretro/LibretroWrapper.cpp
@@ -769,7 +769,10 @@ int LibretroWrapper::Emulate(const char* romPath)
         else
             config4 = config3;
             
-        Util::Config::MergeINISections(&s_runtime_config, config4, cmd_line.config);  
+        Util::Config::MergeINISections(&s_runtime_config, config4, cmd_line.config);
+
+        // After the merge, so an explicit core option beats the on-disk Supermodel.ini
+        LibretroConfigProvider::ApplyDrivingLayout(s_runtime_config);
     }
 
     int exitCode = 0;

--- a/Src/OSD/libretro/LibretroWrapper.h
+++ b/Src/OSD/libretro/LibretroWrapper.h
@@ -44,6 +44,7 @@ public:
     CRTcolor getCRTColors() const { return CRTcolors; }
     Game getGame() const { return game; }
     IEmulator* getEmulator() const { return Model3; }
+    void Reset();   // hard reset of the emulated machine (retro_reset)
     FrameTimings GetTimings() const;
     std::shared_ptr<CInputSystem> getInputSystem() const { return m_inputSystem; }
     retro_hw_render_callback getHwRender() const { return hw_render; }

--- a/Src/OSD/libretro/libretro.cpp
+++ b/Src/OSD/libretro/libretro.cpp
@@ -709,7 +709,7 @@ void retro_set_video_refresh(retro_video_refresh_t cb)
 
 // --- Stubs (Unused) ---
 
-void retro_reset(void) {}
+void retro_reset(void) { wrapper.Reset(); }
 bool retro_load_game_special(unsigned, const struct retro_game_info *, size_t) { return false; }
 void retro_cheat_reset(void) {}
 void retro_cheat_set(unsigned, bool, const char *) {}

--- a/Src/OSD/libretro/libretro.cpp
+++ b/Src/OSD/libretro/libretro.cpp
@@ -548,13 +548,14 @@ void retro_run(void)
 
       if (++log_frames >= 61) {   // 61: coprime with every frameskip cycle (1..4)
          const float n = (float)log_frames;
-         log_cb(RETRO_LOG_INFO,
-                "[Timing] avg over %u frames | PPC:%4.1f  Render:%4.1f (%u drawn)  "
-                "emu+blit:%5.1f  present:%5.1f  retro_run:%5.1f  worst:%5.1f ms\n",
-                log_frames,
-                acc_ppc / n,
-                rendered ? acc_render / (float)rendered : 0.0f, rendered,
-                acc_emu / n, acc_present / n, acc_run / n, max_run);
+         if (g_options.timing_overlay)
+            log_cb(RETRO_LOG_INFO,
+                   "[Timing] avg over %u frames | PPC:%4.1f  Render:%4.1f (%u drawn)  "
+                   "emu+blit:%5.1f  present:%5.1f  retro_run:%5.1f  worst:%5.1f ms\n",
+                   log_frames,
+                   acc_ppc / n,
+                   rendered ? acc_render / (float)rendered : 0.0f, rendered,
+                   acc_emu / n, acc_present / n, acc_run / n, max_run);
          log_frames = 0; rendered = 0;
          acc_run = acc_emu = acc_present = max_run = 0.0f;
          acc_ppc = acc_render = 0;

--- a/Src/OSD/libretro/libretro.cpp
+++ b/Src/OSD/libretro/libretro.cpp
@@ -65,6 +65,7 @@ CoreOptions g_options = {
                               false,
 #endif
    /* timing_overlay      */ false,
+   /* driving_layout      */ DrivingLayout::Default,
 };
 
 // Optimization: Cache last known resolution to avoid redundant updates

--- a/Src/OSD/libretro/libretro_core_options.h
+++ b/Src/OSD/libretro/libretro_core_options.h
@@ -120,6 +120,21 @@ static struct retro_core_option_v2_definition option_defs[] = {
       "shoulders"
    },
    {
+      "supermodel_driving_layout",
+      "Driving Controls Layout",
+      NULL,
+      "Pad layout for driving games. Default: pedals on the D-pad, gears 1-4 on L/R/L2/R2. Both other layouts put the analog brake on L2 and the analog accelerator on R2, and differ in what the right stick does: a 4-gear gate (up/down/left/right = 1/2/3/4), or a sequential lever (up = shift up, down = shift down, which disables the 4-gear gate). L/R always shift sequentially in both. Takes effect when the game is reloaded.",
+      NULL,
+      "input",
+      {
+         { "default",      "Default (pedals on D-pad, gears on L/R/L2/R2)" },
+         { "triggers",     "Analog Triggers + 4-gear gate on right stick" },
+         { "triggers_seq", "Analog Triggers + sequential on right stick" },
+         { NULL, NULL },
+      },
+      "default"
+   },
+   {
       "supermodel_force_feedback",
       "Force Feedback",
       NULL,
@@ -292,6 +307,12 @@ void update_core_options(void)
    g_options.music_volume = atoi(option_get("supermodel_music_volume", "100"));
 
    g_options.service_on_sticks = strcmp(option_get("supermodel_service_buttons", "shoulders"), "sticks") == 0;
+   {
+      const char *layout = option_get("supermodel_driving_layout", "default");
+      g_options.driving_layout = strcmp(layout, "triggers") == 0     ? DrivingLayout::TriggersGate
+                               : strcmp(layout, "triggers_seq") == 0 ? DrivingLayout::TriggersSequential
+                               : DrivingLayout::Default;
+   }
    g_options.force_feedback = strcmp(option_get("supermodel_force_feedback", "disabled"), "enabled") == 0;
    g_options.analog_sensitivity = atoi(option_get("supermodel_analog_sensitivity", "100"));
 

--- a/Src/OSD/libretro/libretro_core_options.h
+++ b/Src/OSD/libretro/libretro_core_options.h
@@ -52,7 +52,7 @@ static struct retro_core_option_v2_definition option_defs[] = {
       "supermodel_timing_overlay",
       "Frame Timing Overlay",
       NULL,
-      "Show the per-frame timing overlay (PPC/Render/GPU/Total). Costs an extra draw pass every frame, so leave it off unless you are profiling.",
+      "Show the per-frame timing overlay (PPC/Render/GPU/Total) and log timing averages. Costs an extra draw pass every frame, so leave it off unless you are profiling.",
       NULL,
       "video",
       {


### PR DESCRIPTION
Description

  Seven independent fixes found while chasing wrong behaviour on RPi5/Recalbox,
  plus one new option. Each commit stands alone.

  ### ARM64 JIT

  **`faa9fd1` — update FPSCR[FPRF] after FP arithmetic**
  Daytona 2's opponent AI was broken with the JIT enabled: rivals crashed at the
  start and the race was trivially easy. The interpreter updates FPSCR[FPRF]
  (result class/sign) via `set_fprf()` after every FP op; the JIT computed the
  right result but never set the flag, and the AI reads it back with mffs/mcrfs.
  Arithmetic stays native — the flag is set through a small helper rather than
  falling back to the interpreter.

  **`3053b60` — dispatch A-form FP ops on the 5-bit opcode**
  Latent perf bug surfaced by the above: A-form ops were matched on a 10-bit
  extended opcode that includes the frC field, so `fmul`/`fmadd`/`fsel` only
  matched when frC == 0 and silently fell back to the interpreter everywhere
  else. Opcode 59 now masks 5 bits; opcode 63 collapses frC for the A-form
  subset.

  ### Legacy3D

  **`6a10218` — re-enable backface culling every frame**
  Sega Rally 2's SELECT CAR was missing the Subaru Impreza, and the
  Championship/Practice backgrounds were missing too. `glEnable(GL_CULL_FACE)`
  was only set in `SetupGLObjects()`, which runs once: the standalone owns its GL
  context so the state survives, but the libretro core shares it with the
  frontend, which renders its own passes between frames and leaves culling off.
  The whole scene was drawn with back faces intact; where a back face happened to
  be coplanar with what it covered, draw order alone decided the winner. Now set
  in `RenderFrame()` next to the depth/stencil state it already restores.

  **`c9fdee4` — lighten Sega Rally 2 smoke**
  Dust/smoke rendered as opaque coloured cones. They are dozens of overlapping
  translucent RGBA4 polys; plain alpha blending accumulates them to opaque, where
  New3D keeps them light. Per-poly alpha is cut for that specific class of poly.

  ### libretro

  **`46ded10` — make retro_reset actually reset**
  `retro_reset()` was an empty stub under a "Stubs (Unused)" comment, so the
  frontend's Restart did nothing. It now runs the same sequence the uiReset
  hotkey already used, and that hotkey calls it instead of keeping a copy.

  **`8e6cc6b` — driving controls layout option**
  New "Driving Controls Layout" under input. The default is unchanged:

  | | default | triggers | triggers_seq |
  |---|---|---|---|
  | accelerator / brake | d-pad | R2 / L2 (analog) | R2 / L2 (analog) |
  | right stick | – | gears 1-4 | sequential up/down |
  | L / R | gears 1 / 2 | sequential | sequential |
  | L2 / R2 | gears 3 / 4 | pedals | pedals |

  The input system only ever filled the left stick; the right stick (RX/RY) and
  the triggers (Z/RZ) are now exposed as axes. Pads with digital L2/R2 report
  0 or 32767, so the mapping degrades to all-or-nothing rather than breaking.
  The layout is applied to the merged runtime config, not in `DefaultConfig()`:
  the on-disk Supermodel.ini is merged *over* the defaults and carries a full set
  of Input* mappings, so a default set there would never be seen.

  **`c88d892` — gate the [Timing] log**
  The profiler line was emitted every 61 frames unconditionally, spamming the
  frontend log during normal play. It now follows the existing timing overlay
  option.