### PR TITLE
Fix Windows/MinGW build: match platform=win64 and keep the CI toolchain

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,12 @@ libretro-build-windows-x64:
   extends:
     - .libretro-windows-x64-mingw-make-default
     - .core-defs
+  script:
+    - make -C ${MAKEFILE_PATH} -f ${MAKEFILE} -j${NUMPROC}
+    # Fail the job instead of uploading nothing: when the Makefile did not
+    # match platform=win64, make had nothing to do, exited 0 and the job went
+    # green while no DLL was ever produced.
+    - test -f ${MAKEFILE_PATH}/${CORENAME}_libretro.dll
 
 # macOS 64-bit
 libretro-build-osx-x64:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,15 @@ ifeq ($(platform),)
     endif
 endif
 
+# The libretro buildbot passes platform=win64 to the MinGW cross build, and
+# other spellings are in circulation too. Normalize them all to "win" so the
+# Windows branches below actually match -- otherwise no branch matches at all,
+# TARGET stays empty and "make" silently does nothing.
+WIN_PLATFORM := $(filter $(platform),win win32 win64 windows wincross64)
+ifneq (,$(WIN_PLATFORM))
+    platform := win
+endif
+
 # System platform (for native builds)
 system_platform = unix
 ifeq ($(shell uname -a),)
@@ -436,13 +445,31 @@ ifeq ($(platform),win)
     
     ifeq ($(system_platform),win)
         # Native Windows build with MinGW
-        override CC := gcc
-        override CXX := g++
+        ifeq ($(origin CC),default)
+            CC := gcc
+        endif
+        ifeq ($(origin CXX),default)
+            CXX := g++
+        endif
     else
-        # Cross-compile to Windows (from Linux)
-        override CC := x86_64-w64-mingw32-gcc
-        override CXX := x86_64-w64-mingw32-g++
-        override AR := x86_64-w64-mingw32-ar
+        # Cross-compile to Windows (from Linux). Only fall back to the plain
+        # mingw-w64 names when no toolchain was handed to us -- the buildbot's
+        # MXE container exports its own (x86_64-w64-mingw32.static-gcc), and
+        # overriding that would point us at compilers that do not exist there.
+        ifeq ($(WIN_PLATFORM),win32)
+            MINGW_PREFIX ?= i686-w64-mingw32
+        else
+            MINGW_PREFIX ?= x86_64-w64-mingw32
+        endif
+        ifeq ($(origin CC),default)
+            CC := $(MINGW_PREFIX)-gcc
+        endif
+        ifeq ($(origin CXX),default)
+            CXX := $(MINGW_PREFIX)-g++
+        endif
+        ifeq ($(origin AR),default)
+            AR := $(MINGW_PREFIX)-ar
+        endif
     endif
     
     # Static-link MinGW runtimes and zlib so the DLL is self-contained — no


### PR DESCRIPTION
`supermodel_libretro.dll` has never appeared in the Windows nightlies, even though `libretro-build-windows-x64` reports **success** on every pipeline. The job finishes in ~11 s and uploads nothing ([job 2119654](https://git.libretro.com/libretro/Libretro-Supermodel/-/jobs/2119654)):

```
$ make -C . -f Makefile -j${NUMPROC}
PLATFORM_DEFINES ARE: 
make: Nothing to be done for 'all'.
...
mv: cannot stat './supermodel_libretro.dll': No such file or directory
ERROR: No files to upload
Job succeeded
```

`ci-templates/windows-x64-mingw.yml` builds with `platform=win64` and `CC=x86_64-w64-mingw32.static-gcc`. The Makefile only has `ifeq ($(platform),win)` and no catch-all `else`, so with `win64` no branch matches: `TARGET` stays empty, `make` exits 0 with nothing built, and since the failures land in `after_script` the job still goes green. Behind that, the cross path does `override CC := x86_64-w64-mingw32-gcc`, discarding the MXE toolchain the container exports.

The fix:

* Normalize `win`/`win32`/`win64`/`windows`/`wincross64` to `win` after platform auto-detection, so every Windows branch matches — including the `Src/OSD/Windows/FileSystemPath.cpp` selection.
* Use the plain mingw-w64 names only as a fallback when no toolchain was given (`$(origin …)` is `default`); `win32` picks the `i686-` prefix.
* Guard the CI job with `test -f ${CORENAME}_libretro.dll`, so a no-op build fails instead of uploading nothing.

Nothing outside the Windows path changes — `make info` for auto/`unix`/`linux-aarch64`/`android`/`rpi64`/`osx` is identical to before. Built for real from this branch with `platform=win64` and the toolchain passed through the environment, as the buildbot does it: all 108 objects compiled and linked into a 6.4 MB `PE32+ executable (DLL) x86-64`. That used Debian's `g++-mingw-w64-x86-64`, not the MXE `gcc11` image itself, so the first pipeline run is the final word — hence the `test -f` guard.

Note that this touches the same Makefile region as the open #13, so one of the two will need a trivial rebase. #13 does not fix this: its Makefile still has `ifeq ($(platform),win)` and the same `override CC :=` lines.
